### PR TITLE
add default value for $strIcon

### DIFF
--- a/src/Resources/contao/forms/FormCalendarField.php
+++ b/src/Resources/contao/forms/FormCalendarField.php
@@ -87,6 +87,9 @@ class FormCalendarField extends \FormTextField
     }
 
     if ($this->dateImage) {
+      
+      $strIcon = '';
+      
       if (\Validator::isUuid($this->dateImageSRC)) {
         $objModel = \FilesModel::findByUuid($this->dateImageSRC);
 


### PR DESCRIPTION
if image does not exist, the variable is never set and the line 109 triggers a warning in PHP 8+.